### PR TITLE
Handle type aliases better

### DIFF
--- a/examples/alias/src/lib.rs
+++ b/examples/alias/src/lib.rs
@@ -1,0 +1,33 @@
+#[repr(C)]
+struct Dep
+{
+    a: i32,
+    b: f32,
+}
+
+#[repr(C)]
+struct Foo<X>
+{
+    a: X,
+    b: X,
+    c: Dep,
+}
+
+#[repr(u32)]
+enum Status
+{
+    Ok,
+    Err,
+}
+
+type IntFoo = Foo<i32>;
+type DoubleFoo = Foo<f64>;
+
+type Unit = i32;
+type SpecialStatus = Status;
+
+#[no_mangle]
+extern "C" fn root(x: IntFoo, y: DoubleFoo, z: Unit, w: SpecialStatus)
+{
+
+}


### PR DESCRIPTION
This isn't the cleanest patch. `main.rs` could use a refactor, things are getting stringly typed.

Should fix #2